### PR TITLE
Add missing quotes in SolutionGenerationHook.cs

### DIFF
--- a/UnityProject/Assets/Editor/SolutionGenerationHook.cs
+++ b/UnityProject/Assets/Editor/SolutionGenerationHook.cs
@@ -25,7 +25,7 @@ public class SolutionGenerationHook
 
 	private static string AddProjectToSolution(string content, string projectName, string projectFilePath, string projectGuid)
 	{
-		if (content.Contains("" + projectName + ""))
+		if (content.Contains("\"" + projectName + "\""))
 			return content; // already added
 
 		var signature = new StringBuilder();


### PR DESCRIPTION
Add missing quotes in SolutionGenerationHook.cs to determine the assembly name in the .sln file.
When we find already added projects in AddProjectToSolution() `content.Contains("" + projectName + "")` can return "true" if we have several projects and one of them contains the name of the project in its path.